### PR TITLE
Add permissions to the github workflow

### DIFF
--- a/.github/workflows/publish_to_s3.yaml
+++ b/.github/workflows/publish_to_s3.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The last few runs haven't been able to get AWS credentials via the open connect provider, so let's see if this helps.