### PR TITLE
Add the bash scripts used to create AWS resources for this POC

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,53 @@
+# AWS Setup
+
+The bash scripts in this folder were used to setup the AWS resources neeed for the S3-testhub.
+
+They're pretty unfinished and meant to serve as a reference, not as something we'd want to run reguarly or ship to users.
+
+
+## Scripts
+
+
+### aws_setup.sh
+
+This script creates the AWS resources needed to access AWS resources from GitHub Actions using an OpenID Connect (OIDC) identity provider.
+
+Using the OIDC provider (as opposed to storing AWS access keys as repo secrets) requires more initial setup but has these advantages:
+
+- Is the approach recommended by both GitHub and AWS
+- Generates temporary AWS creds for use during a GitHub action (no need to store and rotate long-term creds)
+- Once setup, works very smoothly with [AWS's supported GitHub actions](https://github.com/aws-actions)
+
+`aws_setup.sh` creates the following AWS resources:
+
+1. An OIDC identity provider for GitHub actions (once created, this is available across the AWS account)
+2. An IAM role that can be assumed by GitHub actions*
+3. An S3 bucket to store hub data
+4. An IAM policy that allows write access to the bucket (and is then attached to the role created in step 2)
+
+* In this example, the IAM role for use with GitHub actions is fairly strict, as the `Condition` states that an action must be associated with this repo's main branch to assume it.
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::${aws_account}:oidc-provider/token.actions.githubusercontent.com"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "token.actions.githubusercontent.com:sub": "repo:${org_name}/${hub_name}:ref:refs/heads/main",
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                }
+            }
+        }
+    ]
+}
+```
+
+### aws_teardown.sh
+
+This script deletes the AWS resources created by `aws_setup.sh`. It's very destructive and only included here for testing.

--- a/bootstrap/aws_setup.sh
+++ b/bootstrap/aws_setup.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# Initial setup attempt to auth github actions to AWS resources w/o using explicit secrets
+# Resources:
+#   https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+#   https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/
+# Prerequisies:
+#   - aws cli installed and configured to use admin credentials
+
+aws_account="312560106906"  # Reich Lab AWS account
+hub_name="s3-testhub"  # We'll use hub name as the S3 bucket name
+org_name="Infectious-Disease-Modeling-Hubs"  # the hub's GitHub org
+repo_name="s3-testhub" # in case the repo name <> hub name
+role_name="${hub_name}-githubaction"  # Role that will be assumed by github actions"
+tags="Key=Hub,Value=${hub_name}"  # TODO: make this work with multiple tags and tagsets
+
+# TODO:
+# better error handling when a resource already exists
+# could probably be clever and do some jq just with the output so we don't have to manually contruct the ARNs
+
+# Create the OIDC provider
+# The thumbprint below was retrieved via AWS console on 2024-01-30
+echo "Creating an AWS OIDC provider for use with GitHub Actions..."
+output=$(aws iam create-open-id-connect-provider --url "https://token.actions.githubusercontent.com" --thumbprint-list "1b511abead59c6ce207077c0bf0e0043b1382612" --client-id-list "sts.amazonaws.com" --tags ${tags})
+echo -e "$output\n"
+
+# Create s3 bucket: versioning enabled and publicly-readable
+echo "Creating an S3 bucket for the hub: ${hub_name}..."
+output=$(aws s3api create-bucket --bucket ${hub_name} --region us-east-1)
+echo -e "$output\n"
+if [ $? -ne 0 ]; then
+    echo "Error creating S3 bucket"
+    return 1
+fi
+
+# Tag s3 bucket
+echo "Tagging S3 bucket..."
+aws s3api put-bucket-tagging --bucket ${hub_name} --tagging "TagSet=[{${tags}}]"
+
+# Enable bucket versioning
+echo "Enabling bucket versioning..."
+aws s3api put-bucket-versioning --bucket ${hub_name} --versioning-configuration Status=Enabled
+
+# Make bucket publicly readable
+# TODO: revisit this settings...we might need RestrictPublicBuckets to be false to make hub_connect work
+echo "Making the bucket publicly readable..."
+aws s3api put-public-access-block --bucket ${hub_name} --public-access-block-configuration '{
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": false,
+    "RestrictPublicBuckets": false
+}'
+
+aws s3api put-bucket-policy --bucket ${hub_name} --policy '{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PublicReadGetObject",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::'${hub_name}'/*"
+            ]
+        },
+        {
+            "Sid": "PublicListBucket",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::'${hub_name}'"
+            ]
+        }
+    ]
+}'
+
+if [ $? -ne 0 ]; then
+    echo "Error enablinb public access to S3 bucket"
+    return 1
+fi
+
+# Create a policy that allows writing to the hub's S3 bucket
+echo "Creating an IAM policy that provides write access to the hub's S3 bucket: ${role_name}-policy..."
+s3_policy_document=$(
+cat << EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+             ],
+             "Resource": [
+                "arn:aws:s3:::${hub_name}",
+                "arn:aws:s3:::${hub_name}/*"
+            ]
+        }
+    ]
+}
+EOF
+)
+output=$(aws iam create-policy --policy-name ${role_name}-policy --tags ${tags} --policy-document ${s3_policy_document})
+if [ $? -ne 0 ]; then
+    echo "Error creating IAM policy"
+    return 1
+fi
+echo -e "$output\n"
+
+# create a role that will be used in conjunction with the above policy to permit write operations to the bucket
+echo "Creating the IAM role that will be assumed by GitHub Actions: ${role_name}..."
+policy_document=$(
+cat << EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::${aws_account}:oidc-provider/token.actions.githubusercontent.com"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "token.actions.githubusercontent.com:sub": "repo:${org_name}/${hub_name}:ref:refs/heads/main",
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                }
+            }
+        }
+    ]
+}
+EOF
+)
+# output=$(aws iam create-role --role-name ${role_name} --tags ${tags} --assume-role-policy-document '{
+output=$(aws iam create-role --role-name ${role_name} --tags ${tags} --assume-role-policy-document ${policy_document})
+if [ $? -ne 0 ]; then
+    echo "Error creating IAM role"
+    return 1
+fi
+echo -e "$output\n"
+
+# Attach the policy to the role
+echo "Attaching the S3 write policy to the GitHub actions role..."
+aws iam attach-role-policy --role-name ${role_name} --policy-arn arn:aws:iam::${aws_account}:policy/${role_name}-policy
+

--- a/bootstrap/aws_teardown.sh
+++ b/bootstrap/aws_teardown.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Teardown the AWS resources created for this test repo
+# Prerequisies:
+#   - aws cli installed and configured to use admin credentials
+
+aws_account="312560106906"  # Reich Lab AWS account
+hub_name="s3-testhub"  # We'll use hub name as the S3 bucket name
+org_name="Infectious-Disease-Modeling-Hubs"  # the hub's GitHub org
+repo_name="s3-testhub" # in case the repo name <> hub name
+role_name="${hub_name}-githubaction"  # Role that will be assumed by github actions"
+
+
+aws s3 rm s3://${hub_name}
+aws iam detach-role-policy --role-name ${role_name} --policy-arn arn:aws:iam::${aws_account}:policy/${role_name}-policy
+aws iam delete-policy --policy-arn arn:aws:iam::${aws_account}:policy/${role_name}-policy
+aws iam delete-role --role-name ${role_name}
+aws iam delete-open-id-connect-provider --open-id-connect-provider-arn arn:aws:iam::${aws_account}:oidc-provider/token.actions.githubusercontent.com


### PR DESCRIPTION
Creating a GitHub action to push the hub files to S3 required some initial AWS setup. For now, the setup is codified in bash scripts for future reference. However, once we prove that our S3 storage is working as needed, we would want to think through the process for Hubverse users to create their AWS resources.