### PR TITLE
Remove master from list of branch triggers

### DIFF
--- a/.github/workflows/publish_to_s3.yaml
+++ b/.github/workflows/publish_to_s3.yaml
@@ -3,7 +3,8 @@ name: Upload hub data to cloud storage
 on:
   workflow_dispatch:
   push:
-        branches: [main, master]
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
I had copied the [main, master] list from another workflow but realized that the related AWS IAM role used by this workflow will be limited to the main branch only. 

We may need to revisit this if an older hub with a "master" branch wants to onboard, but for now, let's be consistent between the workflow and the AWS permissions.