### PR TITLE
Bsweger/put account in env

### DIFF
--- a/.github/workflows/publish_to_s3.yaml
+++ b/.github/workflows/publish_to_s3.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+env:
+  # Hubverse AWS account number
+  AWS_ACCOUNT: 767397675902
+
 permissions:
   contents: read
 
@@ -35,7 +39,7 @@ jobs:
       if: env.CLOUD_ENABLED == 'true'
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: arn:aws:iam::767397675902:role/${{ env.CLOUD_STORAGE }}
+        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/${{ env.CLOUD_STORAGE }}
         aws-region: us-east-1
 
     - name: Sync files to cloud storage

--- a/.github/workflows/publish_to_s3.yaml
+++ b/.github/workflows/publish_to_s3.yaml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Configure AWS credentials
       if: env.CLOUD_ENABLED == 'true'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/${{ env.CLOUD_STORAGE }}
         aws-region: us-east-1


### PR DESCRIPTION
Surface the AWS account number as an env variable at the top of the workflow.