### PR TITLE
Bsweger/changes for lambda test

### DIFF
--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -58,8 +58,8 @@ jobs:
           'hub-config'
           'model-abstracts'
           'model-metadata'
-          # temporarily include model-output here
-          'model-output'
+          # model-output removed for lambda testing
+          # 'model-output'
           'target-data'
         )
         for DIRECTORY in "${hub_directories[@]}"

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -343,7 +343,7 @@
             "submissions_due": {
                 "relative_to": "origin_date",
                 "start": -3000,
-                "end": 30
+                "end": 3000
             }
         }
     ]


### PR DESCRIPTION
To use this repo for lambda testing, we don't want to sync model-output data to the root of the S3 bucket _and_ to `raw`

Intead, sync to `raw` only, so we can test the lambda doing the conversion to parquet.