### PR TITLE
Replace tasks and model metadata configs with flusight copies

### DIFF
--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -1,13 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Schema for Modeling Hub model metadata",
-    "description": "This is the schema for model metadata files, please refer to https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Metadata for more information.",
+    "description": "This is the schema for model metadata files, please refer to https://github.com/cdcepi/FluSight-forecast-hub/blob/main/model-metadata/README.md for more information.",
     "type": "object",
     "properties": {
-        "schema_version": {
-            "type": "string",
-            "format": "uri"
-        },
         "team_name": {
             "description": "The name of the team submitting the model",
             "type": "string"
@@ -43,19 +39,17 @@
                     "affiliation": {
                         "type": "string"
                     },
-                    "orcid": {
-                        "type": "string",
-                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
-                    },
                     "email": {
                         "type": "string",
                         "format": "email"
                     },
-                    "twitter": {
-                        "type": "string"
-                    },
-                    "additionalProperties": false
-                }
+                    "orcid": {
+                        "type": "string",
+                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["name", "affiliation", "email"]
             }
         },
         "website_url": {
@@ -81,41 +75,53 @@
                 "OGL-3.0"
             ]
         },
-        "model_details": {
-            "description": "Structured information about the model",
-            "type": "object",
-            "properties": {
-                "data_inputs": {
-                    "description": "List or description of data inputs used by the model",
-                    "type": "string"
-                },
-                "methods": {
-                    "description": "A brief (200 char.) description of the methods used by this model",
-                    "type": "string",
-                    "maxLength": 200
-                },
-                "methods_long": {
-                    "description": "A full description of the methods used by this model.",
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false,
-            "required": ["data_inputs", "methods"]
+        "designated_model": {
+            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization. A team may designate up to two models.",
+            "type": "boolean"
+        },
+        "citation": {
+            "description": "One or more citations for this model",
+            "type": "string"
+        },
+        "team_funding": {
+            "description": "Any information about funding source for the team or members of the team.",
+            "type": "string"
+        },
+        "data_inputs": {
+            "description": "List or description of data inputs used by the model",
+            "type": "string"
+        },
+        "methods": {
+            "description": "A brief (200 char.) description of the methods used by this model",
+            "type": "string",
+            "maxLength": 200
+        },
+        "methods_long": {
+            "description": "A full description of the methods used by this model. Among other details, this should include whether spatial correlation is considered and how the model accounts for uncertainty.",
+            "type": "string"
+        },
+        "ensemble_of_models": {
+            "description": "Indicator for whether this model is an ensemble of any separate component models",
+            "type": "boolean"
         },
         "ensemble_of_hub_models": {
-            "description": "Indicator for whether this model is an ensemble of other Hub models",
+            "description": "Indicator for whether this model is an ensemble specifically of other models submitted to this Hub",
             "type": "boolean"
         }
     },
-    "additionalProperties": true,
+    "additionalProperties": false,
     "required": [
-        "schema_version",
         "team_name",
         "team_abbr",
         "model_name",
         "model_abbr",
         "model_contributors",
         "license",
-        "model_details"
+        "designated_model",
+        "data_inputs",
+        "methods",
+        "methods_long",
+        "ensemble_of_models",
+        "ensemble_of_hub_models"
     ]
 }

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -1,55 +1,37 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.1/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json",
     "rounds": [
         {
             "round_id_from_variable": true,
-            "round_id": "origin_date",
+            "round_id": "reference_date",
             "model_tasks": [
                 {
                     "task_ids": {
-                        "origin_date": {
+                        "reference_date": {
                             "required": null,
                             "optional": [
-                                "2022-10-01",
-                                "2022-10-08",
-                                "2024-01-02",
-                                "2024-01-09",
-                                "2024-01-29",
-                                "2024-02-05",
-                                "2024-02-12",
-                                "2024-02-19",
-                                "2024-02-26",
-                                "2024-03-11",
-                                "2024-03-18",
-                                "2024-03-25",
-                                "2024-04-01",
-                                "2024-04-08",
-                                "2024-04-15",
-                                "2024-04-22",
-                                "2024-04-29"
+                                "2023-10-07", "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11"
                             ]
                         },
                         "target": {
-                            "required": [
-                                "wk inc flu hosp"
-                            ],
-                            "optional": null
+                            "required": null,
+                            "optional": ["wk flu hosp rate change"]
                         },
                         "horizon": {
-                            "required": [
-                                1
-                            ],
-                            "optional": [
-                                2,
-                                3,
-                                4
-                            ]
+                            "required": null,
+                            "optional": [-1, 0, 1, 2, 3]
                         },
                         "location": {
-                            "required": [
-                                "US"
-                            ],
+                            "required": null,
                             "optional": [
+                                "US",
                                 "01",
                                 "02",
                                 "04",
@@ -101,115 +83,88 @@
                                 "54",
                                 "55",
                                 "56",
-                                "72",
-                                "78"
+                                "72"
+                            ]
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2023-09-23", "2023-09-30", "2023-10-07",
+                                "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11", "2024-05-18",
+                                "2024-05-25", "2024-06-01"
                             ]
                         }
                     },
                     "output_type": {
-                        "mean": {
-                            "output_type_id": {
-                                "required": null,
-                                "optional": [
-                                    "NA"
-                                ]
-                            },
-                            "value": {
-                                "type": "integer",
-                                "minimum": 0
-                            }
-                        },
-                        "quantile": {
+                        "pmf": {
                             "output_type_id": {
                                 "required": [
-                                    0.010,
-                                    0.025,
-                                    0.050,
-                                    0.100,
-                                    0.150,
-                                    0.200,
-                                    0.250,
-                                    0.300,
-                                    0.350,
-                                    0.400,
-                                    0.450,
-                                    0.500,
-                                    0.550,
-                                    0.600,
-                                    0.650,
-                                    0.700,
-                                    0.750,
-                                    0.800,
-                                    0.850,
-                                    0.900,
-                                    0.950,
-                                    0.975,
-                                    0.990
+                                    "large_decrease",
+                                    "decrease",
+                                    "stable",
+                                    "increase",
+                                    "large_increase"
                                 ],
                                 "optional": null
                             },
                             "value": {
-                                "type": "integer",
-                                "minimum": 0
+                                "type": "double",
+                                "minimum": 0,
+                                "maximum": 1
                             }
                         }
                     },
                     "target_metadata": [
                         {
-                            "target_id": "wk inc flu hosp",
-                            "target_name": "Weekly incident influenza hospitalizations",
-                            "target_units": "count",
+                            "target_id": "flu hosp rate change",
+                            "target_name": "week ahead weekly influenza hospitalization rate change",
+                            "target_units": "rate per 100,000 population",
                             "target_keys": {
-                                "target": "wk inc flu hosp"
+                                "target": [
+                                    "wk flu hosp rate change"
+                                ]
                             },
-                            "target_type": "continuous",
+                            "target_type": "ordinal",
+                            "description": "This target represents the change in the rate of new hospitalizations per week comparing the week ending on the reference_date to the week ending [horizon] weeks after the reference_date, on target_end_date.",
                             "is_step_ahead": true,
                             "time_unit": "week"
                         }
                     ]
-                }
-            ],
-            "submissions_due": {
-                "relative_to": "origin_date",
-                "start": -6,
-                "end": 1
-            }
-        },
-        {
-            "round_id_from_variable": true,
-            "round_id": "origin_date",
-            "model_tasks": [
+                },
                 {
                     "task_ids": {
-                        "origin_date": {
+                        "reference_date": {
                             "required": null,
                             "optional": [
-                                "2022-10-15",
-                                "2022-10-22",
-                                "2022-10-29"
+                                "2023-10-07", "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11"
                             ]
                         },
                         "target": {
-                            "required": [
-                                "wk inc flu hosp"
-                            ],
-                            "optional": null
+                            "required": null,
+                            "optional": ["wk inc flu hosp"]
                         },
                         "horizon": {
-                            "required": [
-                                1
-                            ],
-                            "optional": [
-                                2,
-                                3,
-                                4
-                            ]
+                            "required": null,
+                            "optional": [-1, 0, 1, 2, 3]
                         },
                         "location": {
-                            "required": [
-                                "US"
-                            ],
+                            "required": null,
                             "optional": [
+                                "US",
                                 "01",
                                 "02",
                                 "04",
@@ -261,66 +216,57 @@
                                 "54",
                                 "55",
                                 "56",
-                                "72",
-                                "78"
+                                "72"
                             ]
                         },
-                        "age_group": {
-                            "required": [
-                                "65+"
-                            ],
+                        "target_end_date": {
+                            "required": null,
                             "optional": [
-                                "0-5",
-                                "6-18",
-                                "19-24",
-                                "25-64"
+                                "2023-09-23", "2023-09-30", "2023-10-07",
+                                "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11", "2024-05-18",
+                                "2024-05-25", "2024-06-01"
                             ]
                         }
                     },
                     "output_type": {
-                        "mean": {
-                            "output_type_id": {
-                                "required": null,
-                                "optional": [
-                                    "NA"
-                                ]
-                            },
-                            "value": {
-                                "type": "integer",
-                                "minimum": 0
-                            }
-                        },
                         "quantile": {
                             "output_type_id": {
                                 "required": [
-                                    0.010,
+                                    0.01,
                                     0.025,
-                                    0.050,
-                                    0.100,
-                                    0.150,
-                                    0.200,
-                                    0.250,
-                                    0.300,
-                                    0.350,
-                                    0.400,
-                                    0.450,
-                                    0.500,
-                                    0.550,
-                                    0.600,
-                                    0.650,
-                                    0.700,
-                                    0.750,
-                                    0.800,
-                                    0.850,
-                                    0.900,
-                                    0.950,
+                                    0.05,
+                                    0.1,
+                                    0.15,
+                                    0.2,
+                                    0.25,
+                                    0.3,
+                                    0.35,
+                                    0.4,
+                                    0.45,
+                                    0.5,
+                                    0.55,
+                                    0.6,
+                                    0.65,
+                                    0.7,
+                                    0.75,
+                                    0.8,
+                                    0.85,
+                                    0.9,
+                                    0.95,
                                     0.975,
-                                    0.990
+                                    0.99
                                 ],
                                 "optional": null
                             },
                             "value": {
-                                "type": "integer",
+                                "type": "double",
                                 "minimum": 0
                             }
                         }
@@ -328,12 +274,15 @@
                     "target_metadata": [
                         {
                             "target_id": "wk inc flu hosp",
-                            "target_name": "Weekly incident influenza hospitalizations",
+                            "target_name": "incident influenza hospitalizations",
                             "target_units": "count",
                             "target_keys": {
-                                "target": "wk inc flu hosp"
+                                "target": [
+                                    "wk inc flu hosp"
+                                ]
                             },
                             "target_type": "continuous",
+                            "description": "This target represents the count of new hospitalizations in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
                             "is_step_ahead": true,
                             "time_unit": "week"
                         }
@@ -341,9 +290,9 @@
                 }
             ],
             "submissions_due": {
-                "relative_to": "origin_date",
-                "start": -3000,
-                "end": 3000
+                "relative_to": "reference_date",
+                "start": -6000,
+                "end": -3000
             }
         }
     ]


### PR DESCRIPTION
The goal of this changeset is to implement config files that will allow copying in UMASS model-outputs from the flusight repo and getting them to pass the validation checks (so we can test with actual hubverse-formatted data)