### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/hub-config/README.md
+++ b/hub-config/README.md
@@ -1,3 +1,3 @@
 # Hub configuation files
 
-This folder should contain configuration files for the Hub, following the recommended [Hub configuration files in our documentation](https://hubverse.io/en/latest/user-guide/hub-config.html).
+This folder should contain configuration files for the Hub, following the recommended [Hub configuration files in our documentation](https://docs.hubverse.io/en/latest/user-guide/hub-config.html).


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.